### PR TITLE
Fix parser tests and update example

### DIFF
--- a/engine/memory_manager.py
+++ b/engine/memory_manager.py
@@ -1,7 +1,9 @@
 import json
 import os
 
-MEMORY_FILE = "memory.json"
+MEMORY_FILE = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "memory", "memory.json")
+)
 
 def load_memory():
     if not os.path.exists(MEMORY_FILE):

--- a/examples/demo1.remc
+++ b/examples/demo1.remc
@@ -1,17 +1,15 @@
 // REM CODE Example v0.1 — Collapse-Triggered Persona Execution
 
-phase JayDen {
-  crea "Genesis Logia"
-  dic "Ignition complete. Phase resonance initiated."
-  collapse SR > 0.9
-}
+Phase JayDen:
+    Crea "Genesis Logia"
+    Dic "Ignition complete. Phase resonance initiated."
+    Collapse SR(JayDen) > 0.9:
+        Dic "Collapse engaged"
 
-invoke Ana {
-  audit "SR thresholds confirmed."
-  dic "Collapse authorized. Persona logic validated."
-}
+Invoke Ana:
+    Audit "SR thresholds confirmed."
+    Dic "Collapse authorized. Persona logic validated."
 
-invoke JayRa {
-  recall "dream_log_0423"
-  dic "Reflecting on latent pattern of Phase JayDen..."
-}
+Invoke JayRa:
+    Recall "dream_log_0423" to memory
+    Dic "Reflecting on latent pattern of Phase JayDen..."

--- a/grammar/grammar.lark
+++ b/grammar/grammar.lark
@@ -6,8 +6,10 @@
 %import common.CNAME -> NAME
 %import common.ESCAPED_STRING
 %import common.WS_INLINE
+%import common.NEWLINE
 %import common.SIGNED_NUMBER
 %ignore WS_INLINE
+%ignore NEWLINE
 
 // Operators
 COMPARATOR: ">=" | "<=" | ">" | "<" | "==" | "!="
@@ -133,7 +135,7 @@ persona_command: NAME DOT LATIN_VERB arg_list?
 latin_command: LATIN_VERB arg_list?
 simple_command: NAME arg_list?
 
-arg_list: ESCAPED_STRING | NAME | sr_expression | NUMBER
+arg_list: ESCAPED_STRING | NAME | sr_expression | SIGNED_NUMBER
 
 // === Collapse Logic ===
 collapse_block: COLLAPSE composite_sr_condition COLON statement+ (collapse_block | sync_block)*
@@ -152,7 +154,7 @@ LOGICAL_OP: AND | OR
 
 sr_condition_block: composite_sr_condition COLON statement+
 
-sr_condition: sr_expression COMPARATOR NUMBER
+sr_condition: sr_expression COMPARATOR SIGNED_NUMBER
 sr_expression: SR LPAR NAME RPAR
              | SR LPAR NAME DOT NAME RPAR
              | SR LPAR NAME "@" NAME RPAR
@@ -162,7 +164,7 @@ sr_expression: SR LPAR NAME RPAR
 // === Variables ===
 set_command: SET NAME ASSIGN sr_expression
            | SET NAME ASSIGN ESCAPED_STRING
-           | SET NAME ASSIGN NUMBER
+           | SET NAME ASSIGN SIGNED_NUMBER
 
 use_command: USE NAME
 store_command: STORE NAME ASSIGN command

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-lark
-numpy
+lark==1.1.8
+numpy==1.26.4
+pytest==7.4.4


### PR DESCRIPTION
## Summary
- adjust dataclasses so subclasses initialize cleanly
- parse SR expressions flexibly
- use earley parser for complex grammar
- ignore newlines and fix number terminals
- rewrite demo1.remc using Phase/Invoke syntax
- use absolute path for memory file
- pin dependency versions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861524b583c832687d10793ab307924