### PR TITLE
Improve logging and test reliability

### DIFF
--- a/bridge/chat_bridge.py
+++ b/bridge/chat_bridge.py
@@ -412,7 +412,7 @@ class REMChatBridge:
                 if not self.trusted:
                     raise PermissionError("Untrusted mode: Python execution disabled")
                 local_env = {"context": context, "params": params or {}}
-                exec(func.code, {}, local_env)
+                exec(func.code, {"__builtins__": {}}, local_env)
                 
                 # Try to call the function
                 if func.name in local_env:

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,0 +1,9 @@
+import logging
+
+# Centralized logging configuration
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(levelname)s:%(name)s:%(message)s'
+)
+
+__all__ = []

--- a/engine/ast_generator.py
+++ b/engine/ast_generator.py
@@ -11,7 +11,6 @@ import os
 import logging
 
 # Configure logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # ==================== AST Node Classes ====================

--- a/engine/interpreter.py
+++ b/engine/interpreter.py
@@ -20,7 +20,6 @@ except ImportError as e:
     raise
 
 # Configure logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # ==================== Enhanced Persona Context ====================

--- a/engine/persona_router.py
+++ b/engine/persona_router.py
@@ -28,7 +28,6 @@ except ImportError:
         )
 
 # Configure logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # ==================== Enhanced Persona Classes ====================
@@ -94,7 +93,8 @@ class REMPersona:
                     {"PHS": sr, "SYM": sr, "VAL": sr, "EMO": sr, "FX": sr}, 
                     context, self.profile.name
                 )
-            except:
+            except Exception as e:
+                logger.error("Contextual SR computation failed", exc_info=e)
                 adjusted_sr = sr
         else:
             adjusted_sr = sr
@@ -336,7 +336,8 @@ class PersonaRouter:
             routing_result = self.route_personas(metrics, weights, context, detailed)
             routing_result["sr_trace"] = sr_trace.to_dict()
             return routing_result
-        except:
+        except Exception as e:
+            logger.error("Routing with SR trace failed", exc_info=e)
             # Fallback to basic routing
             return self.route_personas(metrics, weights, context, detailed)
     

--- a/engine/rem_executor.py
+++ b/engine/rem_executor.py
@@ -12,7 +12,6 @@ from typing import Dict, List, Union, Any, Optional, Tuple
 from dataclasses import dataclass, field
 
 # Configure logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # ==================== Execution Context ====================

--- a/engine/sr_engine.py
+++ b/engine/sr_engine.py
@@ -11,7 +11,6 @@ from typing import Dict, List, Optional, Tuple, Any
 from dataclasses import dataclass, field
 
 # Configure logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # === SR標準重み設定（Collapse Spiral国家標準） ===

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -13,7 +13,9 @@ except ImportError:
 from engine.interpreter import REMInterpreter
 
 def test_run_demo():
-    code = pathlib.Path('examples/demo1.remc').read_text(encoding='utf-8')
+    base = pathlib.Path(__file__).resolve().parents[1]
+    code_path = base / 'examples' / 'demo1.remc'
+    code = code_path.read_text(encoding='utf-8')
     interpreter = REMInterpreter()
     results = interpreter.run_rem_code(code)
     assert isinstance(results, list)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -12,7 +12,9 @@ except ImportError:
 from engine.ast_generator import create_ast_generator
 
 def test_parse_demo():
-    code = pathlib.Path('examples/demo1.remc').read_text(encoding='utf-8')
+    base = pathlib.Path(__file__).resolve().parents[1]
+    code_path = base / 'examples' / 'demo1.remc'
+    code = code_path.read_text(encoding='utf-8')
     generator = create_ast_generator()
     ast = generator.generate_ast(code)
     assert isinstance(ast, list)


### PR DESCRIPTION
## Summary
- centralize logging configuration in `engine/__init__.py`
- drop `logging.basicConfig()` calls in engine modules
- handle exceptions explicitly in `persona_router`
- sandbox `exec()` in `REMChatBridge`
- use file‑relative paths in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861560447b08326a5520554b15c144a