### PR TITLE
Fix path resolution and recall parsing

### DIFF
--- a/engine/ast_generator.py
+++ b/engine/ast_generator.py
@@ -277,11 +277,18 @@ class REMTransformer(Transformer):
         return SignBlock(content="", persona="", reason=str(reason))
     
     # ===== Memory & Transitions =====
-    def recall_block(self, content, target, from_memory=False):
+    def recall_block(self, *items):
+        """Handle recall operations to or from memory"""
+        tokens = [str(it) for it in items]
+        # tokens[1] should be the quoted content
+        content = tokens[1] if len(tokens) > 1 else ""
+        # Determine if we are recalling from memory (presence of 'from')
+        from_memory = "from" in tokens
+        target = tokens[-1] if tokens else ""
         return RecallBlock(
             content=str(content),
             target=str(target),
-            from_memory=from_memory
+            from_memory=from_memory,
         )
     
     def memoryset_block(self, variable, content):

--- a/functions/functions.py
+++ b/functions/functions.py
@@ -138,8 +138,8 @@ class REMFunctionManager:
     
     def _get_default_memory_path(self) -> str:
         """Get default memory file path"""
-        base_dir = Path(__file__).parent.parent
-        memory_dir = base_dir / "memory"
+        base_dir = Path(__file__).resolve().parent.parent
+        memory_dir = (base_dir / "memory").resolve()
         memory_dir.mkdir(exist_ok=True)
         return str(memory_dir / "functions.json")
     


### PR DESCRIPTION
## Summary
- ensure absolute path for function memory file
- handle recall grammar tokens correctly in the AST generator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68615aa8a6708326be2e9f29f11ace3d