### PR TITLE
Centralize logging in engine

### DIFF
--- a/bridge/chat_bridge.py
+++ b/bridge/chat_bridge.py
@@ -25,8 +25,7 @@ except ImportError as e:
     def compute_sr_trace(*args, **kwargs):
         return {"SR": 0.8, "persona": "Fallback"}
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
+# Logger instance
 logger = logging.getLogger(__name__)
 
 # ==================== Enhanced Data Structures ====================

--- a/codex_agent.py
+++ b/codex_agent.py
@@ -10,8 +10,6 @@ import subprocess
 import logging
 from pathlib import Path
 
-logging.basicConfig(level=logging.INFO)
-
 TASK_FILE = "tasks/agent_task.json"
 PROJECT_ROOT = Path(__file__).parent.resolve()
 

--- a/functions/functions.py
+++ b/functions/functions.py
@@ -30,8 +30,7 @@ try:
 except ImportError:
     generate_zine_from_function = lambda name, lines: f"ZINE for {name}: {len(lines)} lines"
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
+# Logger instance
 logger = logging.getLogger(__name__)
 
 # ==================== Enhanced Data Structures ====================


### PR DESCRIPTION
## Summary
- remove redundant logging config from chat bridge
- remove logging config from function manager
- drop logging setup from codex_agent
- keep logging configuration only in `engine/__init__.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861603c34f08326badd5c5942c17b57