### PR TITLE
Update parse_demo path handling

### DIFF
--- a/parse_demo.py
+++ b/parse_demo.py
@@ -1,16 +1,23 @@
+from pathlib import Path
 from lark import Lark
 from engine.rem_transformer import REMTransformer
 import json
 
-def parse_remc(file_path):
-    # 文法読み込み
-    with open("grammar/grammar.lark", "r", encoding="utf-8") as f:
+BASE_DIR = Path(__file__).resolve().parent
+
+
+def parse_remc(file_path: str):
+    """Parse a REMC file using the bundled grammar."""
+    grammar_path = BASE_DIR / "grammar" / "grammar.lark"
+    with open(grammar_path, "r", encoding="utf-8") as f:
         grammar = f.read()
 
     parser = Lark(grammar, parser="lalr", transformer=REMTransformer())
     
-    # コード読み込み
-    with open(file_path, "r", encoding="utf-8") as f:
+    code_path = Path(file_path)
+    if not code_path.is_absolute():
+        code_path = BASE_DIR / code_path
+    with open(code_path, "r", encoding="utf-8") as f:
         code = f.read()
 
     try:


### PR DESCRIPTION
## Summary
- ensure `parse_demo.py` loads grammar and demo file relative to its own location

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686181e345f083269428277ac7bef8ad