### PR TITLE
Refactor PersonaProfile into shared module

### DIFF
--- a/bridge/chat_bridge.py
+++ b/bridge/chat_bridge.py
@@ -16,7 +16,8 @@ from pathlib import Path
 # Import REM CODE components
 try:
     from engine.sr_engine import compute_sr_trace, compute_contextual_sr, DEFAULT_WEIGHTS
-    from engine.interpreter import REMInterpreter, PersonaProfile
+    from engine.interpreter import REMInterpreter
+    from engine.persona_profile import PersonaProfile
     from engine.ast_generator import create_ast_generator
     from functions.functions import define_function, call_function, list_functions, generate_ast, memory
 except ImportError as e:

--- a/engine/interpreter.py
+++ b/engine/interpreter.py
@@ -8,7 +8,6 @@ Provides high-level interface for REM CODE execution
 import sys
 import logging
 from typing import Dict, List, Any, Optional, Union
-from dataclasses import dataclass, field
 
 # Import REM CODE components
 try:
@@ -22,38 +21,9 @@ except ImportError as e:
 # Configure logging
 logger = logging.getLogger(__name__)
 
-# ==================== Enhanced Persona Context ====================
+from engine.persona_profile import PersonaProfile
 
-@dataclass
-class PersonaProfile:
-    """Enhanced persona profile with SR characteristics"""
-    name: str
-    
-    # SR Component values (0.0 - 1.0)
-    phs: float = 0.8    # Phase Alignment Score
-    sym: float = 0.8    # Symbolic Syntax Match
-    val: float = 0.8    # Semantic Modulation Alignment
-    emo: float = 0.8    # Emotional Phase Match
-    fx: float = 0.8     # Collapse History Interference
-    
-    # Additional characteristics
-    specialization: str = "General"
-    activation_threshold: float = 0.6
-    description: str = ""
-    
-    def get_sr_dict(self) -> Dict[str, float]:
-        """Get SR metrics as dictionary"""
-        return {
-            "PHS": self.phs,
-            "SYM": self.sym,
-            "VAL": self.val,
-            "EMO": self.emo,
-            "FX": self.fx
-        }
-    
-    def compute_sr(self, weights: Optional[Dict[str, float]] = None) -> float:
-        """Compute SR for this persona"""
-        return compute_sr_from_dict(self.get_sr_dict(), weights or DEFAULT_WEIGHTS)
+# ==================== Enhanced Persona Context ====================
 
 # ==================== Default Persona Context ====================
 

--- a/engine/persona_profile.py
+++ b/engine/persona_profile.py
@@ -1,0 +1,56 @@
+"""Persona profile dataclass shared by REM components."""
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Any
+
+from .sr_engine import compute_sr_from_dict, DEFAULT_WEIGHTS
+
+
+@dataclass
+class PersonaProfile:
+    """Unified persona profile with SR metrics and activation data."""
+
+    name: str
+    icon: str = ""
+
+    # SR Component values (0.0 - 1.0)
+    phs: float = 0.8
+    sym: float = 0.8
+    val: float = 0.8
+    emo: float = 0.8
+    fx: float = 0.8
+
+    # Activation thresholds
+    threshold: float = 0.75
+    resonance_threshold: float = 0.9
+    listening_threshold: float = 0.6
+
+    # Additional characteristics
+    specialization: str = "General"
+    description: str = ""
+    activation_threshold: float = 0.6
+
+    # Persona-specific SR preferences
+    sr_preferences: Dict[str, float] = field(default_factory=dict)
+
+    # Activation history and state
+    activation_count: int = 0
+    last_activation: Optional[float] = None
+    total_runtime: float = 0.0
+    current_state: Any = None
+    current_sr: float = 0.0
+
+    def get_sr_dict(self) -> Dict[str, float]:
+        """Return SR metrics as a dictionary."""
+        return {
+            "PHS": self.phs,
+            "SYM": self.sym,
+            "VAL": self.val,
+            "EMO": self.emo,
+            "FX": self.fx,
+        }
+
+    def compute_sr(self, weights: Optional[Dict[str, float]] = None) -> float:
+        """Compute SR value for this persona."""
+        return compute_sr_from_dict(self.get_sr_dict(), weights or DEFAULT_WEIGHTS)
+

--- a/engine/persona_router.py
+++ b/engine/persona_router.py
@@ -7,8 +7,9 @@ Implements complete Collapse Spiral persona activation with SR-based routing
 import time
 import logging
 from typing import Dict, List, Optional, Any, Tuple
-from dataclasses import dataclass, field
 from enum import Enum
+
+from engine.persona_profile import PersonaProfile
 
 try:
     from engine.sr_engine import (
@@ -39,33 +40,6 @@ class PersonaState(Enum):
     ACTIVE = "active"             # Above threshold, engaged
     RESONANT = "resonant"         # High SR, peak performance
     COLLAPSED = "collapsed"       # Post-activation cooldown
-
-@dataclass
-class PersonaProfile:
-    """Enhanced persona profile with complete REM characteristics"""
-    name: str
-    icon: str
-    
-    # Activation thresholds
-    threshold: float = 0.75
-    resonance_threshold: float = 0.9    # High-performance threshold
-    listening_threshold: float = 0.6    # Monitoring threshold
-    
-    # Persona characteristics
-    specialization: str = "General"
-    description: str = ""
-    
-    # SR preferences (persona-specific weight adjustments)
-    sr_preferences: Dict[str, float] = field(default_factory=dict)
-    
-    # Activation history
-    activation_count: int = 0
-    last_activation: Optional[float] = None
-    total_runtime: float = 0.0
-    
-    # Current state
-    current_state: PersonaState = PersonaState.DORMANT
-    current_sr: float = 0.0
 
 class REMPersona:
     """Enhanced REM Persona with comprehensive state management"""


### PR DESCRIPTION
## Summary
- add `engine/persona_profile.py`
- import `PersonaProfile` from new module in interpreter, persona_router and chat_bridge
- remove old duplicated dataclass definitions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686181eb6c848326b529df141bbf6be1